### PR TITLE
Callback URL

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -72,6 +72,7 @@ $message2->setSendTime(time() + 3600);
 $message2->setClass(SMSMessage::CLASS_PREMIUM);
 $message2->setUserReference('customer1');
 $message2->setTags(['%NAME%', '%CODE%']);
+$message2->setCallbackUrl('https://example.com/callback');
 
 $message2->addRecipient(new Recipient(4587652222, ['Martha', '42442']));
 

--- a/src/Entities/Request/SMSMessage.php
+++ b/src/Entities/Request/SMSMessage.php
@@ -17,6 +17,7 @@ use nickdnk\GatewayAPI\Entities\Constructable;
  * @property string[]    $tags
  * @property int         $sendtime
  * @property string      $userref
+ * @property string      $callbackUrl
  * @package nickdnk\GatewayAPI
  */
 class SMSMessage implements JsonSerializable
@@ -28,7 +29,7 @@ class SMSMessage implements JsonSerializable
     const CLASS_PREMIUM  = 'premium';
     const CLASS_SECRET   = 'secret';
 
-    private $message, $sender, $recipients, $tags, $sendtime, $class, $userref;
+    private $message, $sender, $recipients, $tags, $sendtime, $class, $userref, $callbackUrl;
 
     /**
      * @inheritDoc
@@ -62,7 +63,8 @@ class SMSMessage implements JsonSerializable
                 array_key_exists('userref', $array) ? $array['userref'] : null,
                 $array['tags'],
                 array_key_exists('sendtime', $array) ? $array['sendtime'] : null,
-                $array['class']
+                $array['class'],
+                array_key_exists('callback_url', $array) ? $array['callback_url'] : null
             );
 
         }
@@ -81,9 +83,11 @@ class SMSMessage implements JsonSerializable
      * @param string[]    $tags
      * @param int|null    $sendTime
      * @param string      $class
+     * @param string|null $callbackUrl
      */
     public function __construct(string $message, string $senderName, array $recipients = [],
-        ?string $userReference = null, array $tags = [], ?int $sendTime = null, string $class = self::CLASS_STANDARD
+        ?string $userReference = null, array $tags = [], ?int $sendTime = null, string $class = self::CLASS_STANDARD,
+        ?string $callbackUrl = null
     )
     {
 
@@ -93,6 +97,7 @@ class SMSMessage implements JsonSerializable
         $this->userref = $userReference;
         $this->tags = $tags;
         $this->sendtime = $sendTime;
+        $this->callbackUrl = $callbackUrl;
         $this->setClass($class);
 
     }
@@ -182,6 +187,14 @@ class SMSMessage implements JsonSerializable
         return $this->userref;
     }
 
+    /**
+     * @return string
+     */
+    public function getCallbackUrl(): string
+    {
+        return $this->callbackUrl;
+    }
+
 
     /**
      * @param int $sendTime
@@ -201,6 +214,13 @@ class SMSMessage implements JsonSerializable
         $this->userref = $userReference;
     }
 
+    /**
+     * @param string $callbackUrl
+     */
+    public function setCallbackUrl(string $callbackUrl): void
+    {
+        $this->callbackUrl = $callbackUrl;
+    }
 
     /**
      * Sets the send-time of the message to null. Messages with no send time are sent immediately.
@@ -262,6 +282,10 @@ class SMSMessage implements JsonSerializable
 
         if ($this->sendtime !== null) {
             $json['sendtime'] = $this->sendtime;
+        }
+
+        if ($this->callbackUrl !== null) {
+            $json['callback_url'] = $this->callbackUrl;
         }
 
         return $json;

--- a/tests/SMSMessageTest.php
+++ b/tests/SMSMessageTest.php
@@ -20,7 +20,8 @@ class SMSMessageTest extends TestCase
                     'Hello! This is a message to %NAME% aged %AGE%!', 'Apple', [
                     new Recipient(4561232323, ['Joe', '22']),
                     new Recipient(4577364722, ['Mark', '23'])
-                ], 'reference text', ['%NAME%', '%AGE%'], 1585835858, SMSMessage::CLASS_SECRET
+                ], 'reference text', ['%NAME%', '%AGE%'], 1585835858, SMSMessage::CLASS_SECRET,
+                    'https://example.com/callback'
                 )
             )
         );
@@ -36,6 +37,8 @@ class SMSMessageTest extends TestCase
         $this->assertEquals(['Mark', '23'], $self->getRecipients()[1]->getTagValues());
         $this->assertEquals('reference text', $self->getUserReference());
         $this->assertEquals(1585835858, $self->getSendtime());
+
+        $this->assertEquals('https://example.com/callback', $self->getCallbackUrl());
 
     }
 
@@ -155,5 +158,14 @@ class SMSMessageTest extends TestCase
 
         $this->assertEquals($recipients, $message->getRecipients());
 
+    }
+
+    public function testCallbackUrl()
+    {
+
+        $message = new SMSMessage('test', 'sender');
+        $message->setCallbackUrl('https://example.com/callback');
+
+        $this->assertEquals('https://example.com/callback', $message->getCallbackUrl());
     }
 }


### PR DESCRIPTION
This PR adds support for setting the callback URL to be used on a per-SMS level, rather than relying on the default callback URL set in the account settings, by making use of the `callback_url` API parameter (https://gatewayapi.com/docs/rest.html#advanced-usage).

Tests for ensuring this parameter is set correctly have also been added to the `SMSMessageTest` class: a new method  `testCallbackUrl` for testing the new setter method, and an additional parameter in `testConstructFromJSON` to test setting from the long constructor option.